### PR TITLE
Fixes spelling of JukesCantor label

### DIFF
--- a/cdao.owl
+++ b/cdao.owl
@@ -1306,7 +1306,7 @@
     <!-- http://purl.obolibrary.org/obo/CDAO_0000021 -->
 
     <owl:Class rdf:about="&obo;CDAO_0000021">
-        <rdfs:label rdf:datatype="&xsd;string">JukesKantor</rdfs:label>
+        <rdfs:label rdf:datatype="&xsd;string">JukesCantor</rdfs:label>
         <rdfs:subClassOf rdf:resource="&obo;CDAO_0000020"/>
     </owl:Class>
     


### PR DESCRIPTION
See #2. Note that this purposely leaves other files intact that contain the same mis-spelling, specifically `cdao-deprecated-mappings.owl`. This is because there the mis-spelling is in the term IRIs for v1.0 CDAO term IRIs. (One example why using term labels as part of term IRIs
is can be a bad idea.)